### PR TITLE
Allow alternative actions for opening current folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,24 @@
                 "key": "alt+.",
                 "mac": "ctrl+."
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "vscode-quick-browser configuration",
+            "properties": {
+                "vscode-quick-browser.openCurrentFolderAction": {
+                    "type": "string",
+                    "description": "Action to take when selecting '. (current)'",
+                    "enum": [
+                        "none",
+                        "open in same window",
+                        "open in new window",
+                        "open new folder in same window"
+                    ],
+                    "default": "open new folder in same window"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,15 +52,24 @@ function handleDidAccept(qp: vscode.QuickPick<vscode.QuickPickItem>) {
         isDirectory(newPath).then(isDir => {
             if (isDir) {
                 if (selectedLabel === ".") {
-                    const { workspaceFolders } = vscode.workspace
-                    vscode.workspace.updateWorkspaceFolders(
-                        workspaceFolders ? workspaceFolders.length : 0,
-                        null,
-                        { 
-                            uri: vscode.Uri.file(newPath),
-                            name: path.basename(newPath)
-                        }
-                    )
+                    const action = vscode.workspace.getConfiguration( "vscode-quick-browser" ).get( 'openCurrentFolderAction' );
+                    if( action === "open in same window" ) {
+                        vscode.commands.executeCommand( 'vscode.openFolder', new vscode.Uri( { scheme: 'file', path: qp.placeholder } ), false );
+                    }
+                    else if( action === "open in new window" ) {
+                        vscode.commands.executeCommand( 'vscode.openFolder', new vscode.Uri( { scheme: 'file', path: qp.placeholder } ), true );
+                    }
+                    else if( action === "open new folder in same window" ) {
+                        const { workspaceFolders } = vscode.workspace
+                        vscode.workspace.updateWorkspaceFolders(
+                            workspaceFolders ? workspaceFolders.length : 0,
+                            null,
+                            {
+                                uri: vscode.Uri.file(newPath),
+                                name: path.basename(newPath)
+                            }
+                        )
+                    }
                 }
                 else {
                     updateQuickPick(qp, newPath)


### PR DESCRIPTION
Hi Chris

I found that it would create a new folder in the workspace even if I wasn't using a workspace folder, so I've made a change so it is explicitly configurable.

I tested it as javascript, but typescript is new territory for me, so hopefully it should still work correctly!